### PR TITLE
Moved production dependencies from dev to prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "@craco/craco": "^6.2.0",
     "@testing-library/user-event": "^12.8.3",
     "aos": "^3.0.0-beta.6",
+    "autoprefixer": "^10.3.4",
     "axios": "^0.21.1",
+    "postcss": "^8.3.6",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -17,6 +19,7 @@
     "react-transition-group": "^4.4.2",
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
+    "tailwindcss": "^2.2.14",
     "web-vitals": "^1.1.2"
   },
   "scripts": {
@@ -48,7 +51,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.13.0",
     "@testing-library/react": "^11.2.7",
-    "autoprefixer": "^9.8.6",
     "cypress": "^7.5.0",
     "deep-freeze": "^0.0.1",
     "eslint": "^7.29.0",
@@ -57,9 +59,7 @@
     "eslint-plugin-jsdoc": "^35.3.2",
     "eslint-plugin-react": "^7.24.0",
     "jsdocs": "^0.0.1",
-    "postcss": "^7.0.36",
-    "redux-devtools-extension": "^2.13.9",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.7"
+    "redux-devtools-extension": "^2.13.9"
   },
   "react-dotenv": {
     "whitelist": [


### PR DESCRIPTION
Tailwindcss, autoprefixer and postcss are all incorrectly
labeled as developer depenedencies. They have been moved
to production dependencies.

Signed-off-by: Oussama Saoudi <oussama.sa216@gmail.com>